### PR TITLE
Add location to activity info

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,12 +59,14 @@ def agenda(msg):
         event = api[n + 1]
 
     name = event.get('name')
+    location = event.get('location')
+    participants = event.get('participant_counter')
     start = date_to_string(event)
 
     if event.get('poster') is None:
-        bot.sendMessage(chat_id, f'{name} ({event.get("participant_counter")})\n{start}')
+        bot.sendMessage(chat_id, f'{name} ({participants})\n{start}\nLocatie: {location}')
     else:
-        bot.sendPhoto(chat_id, event.get('poster'), f'{name} ({event.get("participant_counter")})\n{start}')
+        bot.sendPhoto(chat_id, event.get('poster'), f'{name} ({participants})\n{start}\nLocatie: {location}')
 
 
 def bier(msg):


### PR DESCRIPTION
Thought I'd add the remaining field from the API that wasn't integrated yet.

While I was at it, also created a variable for the count of participants, to make it more readable :)

It might also be interesting to mention that there's also a more elaborate API for the details of a specific activity, which is only available when you're logged in.

Endpoint: `https://leden.svsticky.nl/api/activities/ + {activity_id}`
Example: https://leden.svsticky.nl/api/activities/440

*Edit: Fixed links.*